### PR TITLE
Reduce required fields in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_report.yml
+++ b/.github/ISSUE_TEMPLATE/issue_report.yml
@@ -27,7 +27,7 @@ body:
       label: Steps to reproduce
       description: List the steps that led to the error. 1) Go to '...', 2) Click on '...', 3) Scroll down to '...', 4) See error
     validations:
-      required: true
+      required: false
   - type: textarea
     id: expected-behavior
     attributes:
@@ -55,7 +55,7 @@ body:
         - Ubuntu 24.04
         - Other. Please specify in Additional context section.
     validations:
-      required: true
+      required: false
   - type: dropdown
     id: browser
     attributes:
@@ -69,14 +69,14 @@ body:
         - Edge
         - Other. Please specify in Additional context section.
     validations:
-      required: true
+      required: false
   - type: textarea
     id: app-version
     attributes:
       label: Application version
       description: Please specify the version of the application you are using.
     validations:
-      required: true
+      required: false
   - type: textarea
     id: additional-context
     attributes:


### PR DESCRIPTION
This PR updates the issue template so that the only required fields are:

1. Description
2. Correlation ID
3. Expected behaviour